### PR TITLE
Create container for DynamoDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM openjdk
+
+RUN apt-get update && \
+    apt-get upgrade -y awscli
+
+WORKDIR /home/docker
+ENV DATADIR=/var/lib/dynamo
+ENV AWS_ACCESS_KEY_ID=dummy
+ENV AWS_SECRET_ACCESS_KEY=dummy
+ENV AWS_DEFAULT_REGION=eu-west-1
+
+RUN /usr/bin/curl -L https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/dynamodb_local_latest.tar.gz | /bin/tar xz
+
+EXPOSE 6060
+VOLUME $DATADIR
+
+COPY entrypoint.sh /root/entrypoint.sh
+COPY create_tables/submitted_responses.sh /root/create_tables/submitted_responses.sh
+
+# Configure a sane default Java heap size (that can be overridden).
+ENV JAVA_OPTS "-Xmx256m"
+
+ENTRYPOINT ["/root/entrypoint.sh", "-dbPath /var/lib/dynamo"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# eq-dynamodb-docker
+# DynamoDB
+A docker container appliance wrapping DynamoDB Local, for use testing and
+developing against Amazon's DynamoDB.
+
+To use it, run the container and connect to port 6060:
+
+docker run -it -p 6060:8000 onsdigital/eq-docker-dynamodb:latest

--- a/create_tables/submitted_responses.sh
+++ b/create_tables/submitted_responses.sh
@@ -1,0 +1,10 @@
+sleep 5
+# Create dev-submitted-responses table.
+
+aws dynamodb --endpoint http://localhost:8000/ create-table \
+	--table-name dev-submitted-responses \
+    --attribute-definitions AttributeName=tx_id,AttributeType=S \
+	--key-schema AttributeName=tx_id,KeyType=HASH \
+	--provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1
+
+aws dynamodb --endpoint http://localhost:8000/ list-tables

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sh /root/create_tables/submitted_responses.sh & java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb


### PR DESCRIPTION
### What is the context of this PR?
Creates a DynamoDB container for local testing.

### How to review 
Run the following on the command line from within the branch:
docker build -t mydynamodb .
docker run -it -p 6060:8000 mydynamodb

This should build the container with table "_dev-submitted-responses_" within it.
To confirm the container is created go to: 
__http://localhost:6060/shell/__

To confirm the table exists run: 
__aws dynamodb --endpoint http://localhost:6060/ list-tables__ on the command line.